### PR TITLE
Fixed compile-time bug on GNU CPP 7.0.5

### DIFF
--- a/life_object.cpp
+++ b/life_object.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "stdafx.h"
 #include "life_object.h"
 


### PR DESCRIPTION
FIxes the following error when on `make`:
```
   life_object.cpp:74:2: error: ‘sort’ was not declared in this scope
```
With this fix, `make` finishes normally and the resulting `life`executable works perfectly.

PS: GNU CPP 7.0.5 is the default C++ compiler on Ubuntu 18.04.